### PR TITLE
Now allows sending complete files + avoids global variable scope pollution + added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 *.vsix
 TODO
 scrap
+out
+
+


### PR DESCRIPTION
Thanks a lot for this extension!

We're developing [Maya2glTF](https://github.com/WonderMediaProductions/Maya2glTF), and we need to do a lot of MEL coding, so this extension looks great.

I noticed that I was unable to send complete files to Maya on Windows (not sure about other OSes). This was also an issue with the MayaPort extension.

As a workaround, I write all the text to a temp file, and execute that file in Maya by scripting it.

I also placed selected text between `{ }` to avoid global variable scope pollution.

I also added `.editorconfig`, because my personal config is spaces instead of tabs, so having that helps for other contributors.

Not sure if this is useful for you, but for me, this patch is essential 😉 

Keep up the great work!


